### PR TITLE
Bug #566: Sharepoint Planner metric source does not throw an exceptio…

### DIFF
--- a/backend/hqlib/__init__.py
+++ b/backend/hqlib/__init__.py
@@ -15,4 +15,4 @@ limitations under the License.
 """
 
 NAME = "HQ"
-VERSION = "2.79.2"
+VERSION = "2.79.3"

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,3 +1,8 @@
+2018-11-21  Release 2.79.3
+
+  * Bug #566: Sharepoint Planner metric source does not throw an exception when refresh token is an empty string.
+
+
 2018-11-21  Release 2.79.2
 
   * Bug: SilkPerformer was still mentioned in urls to the ICTU performance reports.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HQ",
-  "version": "2.79.2",
+  "version": "2.79.3",
   "description": "Holistic Software Quality Reporting",
   "main": "index.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=nl.ictu:hq
 # this is the name and version displayed in the SonarQube UI. Was mandatory prior to SonarQube 6.1.
 sonar.projectName=HQ
-sonar.projectVersion=2.79.2
+sonar.projectVersion=2.79.3
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # Since SonarQube 4.2, this property is optional if sonar.modules is set.


### PR DESCRIPTION
…n when refresh token is an empty string.