### PR TITLE
Update US date parser to allow optional comma after year

### DIFF
--- a/backend/hqlib/utils.py
+++ b/backend/hqlib/utils.py
@@ -67,7 +67,7 @@ _TIME_RE = "(?P<hour>[0-9]{1,2}):(?P<minute>[0-9]{2}):(?P<second>[0-9]{2})"
 _AM_PM_RE = "(?P<am_pm>[AP]M)"
 
 # US format: 'Apr 5, 2013 10:04:10 AM'
-_US_DATE_TIME_RE = _MONTHNAME_RE + r"\s+" + _DAY_RE + r",\s+" + _YEAR_RE + r"\s+" + _TIME_RE + r"\s+" + _AM_PM_RE
+_US_DATE_TIME_RE = _MONTHNAME_RE + r"\s+" + _DAY_RE + r",\s+" + _YEAR_RE + r",?\s+" + _TIME_RE + r"\s+" + _AM_PM_RE
 # ISO date: '2013-11-05'
 _ISO_DATE_RE = "-".join([_YEAR_RE, _MONTH_RE, _DAY_RE])
 

--- a/backend/tests/unittests/utils_tests.py
+++ b/backend/tests/unittests/utils_tests.py
@@ -239,6 +239,10 @@ class ParseUSDateTimeTest(unittest.TestCase):
         """ Test that parsing an invalid string throws an exception. """
         self.assertRaises(ValueError, utils.parse_us_date_time, 'Apr -1')
 
+    def test_extended_format(self):
+        """ Test that parsing an extended format string (ie with additional comma) is parsed correctly. """
+        self.assertEqual(datetime.datetime(2019, 2, 27, 15, 29, 0), utils.parse_us_date_time('Feb 27, 2019, 3:29:00 PM'))
+
 
 class ParseISODateTest(unittest.TestCase):
     """ Unit tests for the parse ISO date method. """

--- a/backend/tests/unittests/utils_tests.py
+++ b/backend/tests/unittests/utils_tests.py
@@ -241,7 +241,7 @@ class ParseUSDateTimeTest(unittest.TestCase):
 
     def test_extended_format(self):
         """ Test that parsing an extended format string (ie with additional comma) is parsed correctly. """
-        self.assertEqual(datetime.datetime(2019, 2, 27, 15, 29, 0), utils.parse_us_date_time('Feb 27, 2019, 3:29:00 PM'))
+        self.assertEqual(datetime.datetime(2019, 2, 27, 15, 9, 0), utils.parse_us_date_time('Feb 27, 2019, 3:09:00 PM'))
 
 
 class ParseISODateTest(unittest.TestCase):


### PR DESCRIPTION
This update is needed for newer versions of JaCoCo to function correctly.